### PR TITLE
Fix compilation issue on `Proxy` with last version of http client

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "a42fe83781b5c4822e00706eaf6a4380b256be8a",
-          "version": "1.0.0-alpha.1"
+          "revision": "037b70291941fe43de668066eb6fb802c5e181d2",
+          "version": "1.1.1"
         }
       },
       {
@@ -15,8 +15,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "334815f6580b5256409d48431751938c4e966e72",
-          "version": "2.4.0"
+          "revision": "e876fb37410e0036b98b5361bb18e6854739572b",
+          "version": "2.16.0"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "b4dbfacff47fb8d0f9e0a422d8d37935a9f10570",
+          "version": "1.4.0"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "77173ac9038e8e9b92f3efe8780923447e3c890b",
-          "version": "2.1.1"
+          "revision": "ae213938e151964aa691f0e902462fbe06baeeb6",
+          "version": "2.7.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "GitHubKitMocks", targets: ["GitHubKitMocks"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0-alpha.2")
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.1")
     ],
     targets: [
         .target(

--- a/Sources/GitHubKit/GitHub.swift
+++ b/Sources/GitHubKit/GitHub.swift
@@ -50,7 +50,7 @@ public class GitHub: GitHubClient {
     let client: AsyncHTTPClient.HTTPClient
     
     /// Initializer
-    public init(_ config: Config, eventLoopGroupProvider provider: AsyncHTTPClient.HTTPClient.EventLoopGroupProvider = .createNew, proxy: AsyncHTTPClient.HTTPClient.Proxy? = nil) throws {
+    public init(_ config: Config, eventLoopGroupProvider provider: AsyncHTTPClient.HTTPClient.EventLoopGroupProvider = .createNew, proxy: AsyncHTTPClient.HTTPClient.Configuration.Proxy? = nil) throws {
         self.config = config
         var conf = AsyncHTTPClient.HTTPClient.Configuration()
         conf.proxy = proxy


### PR DESCRIPTION
the error occurs even if package swift is not updated
`.package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0-alpha.2")` will download the 1.1.1