### PR TITLE
Make github QueryableProperty instance public again

### DIFF
--- a/Sources/GitHubKit/Query.swift
+++ b/Sources/GitHubKit/Query.swift
@@ -6,7 +6,7 @@ public struct QueryableProperty<QueryableType> {
     /// Queryable element accessor
     public var element: QueryableType?
     
-    let github: GitHubClient
+    public let github: GitHubClient
     
     init(_ obj: QueryableType? = nil, github: GitHubClient) {
         element = obj


### PR DESCRIPTION
This re-enables users to create custom Queryable endpoints on Swift 5.4.