### PR TITLE
Add delete overload func and protocol to allow file delete

### DIFF
--- a/Sources/GitHubKit/GitHub.swift
+++ b/Sources/GitHubKit/GitHub.swift
@@ -156,6 +156,11 @@ extension GitHub {
             return self.eventLoop.makeSucceededFuture(Void())
         }
     }
+
+    /// Delete a file
+    public func delete<C, E>(path: String, post: E) throws -> EventLoopFuture<C?> where C: Decodable, E: Encodable {
+        return try send(method: .DELETE, path: path, post: post)
+    }
     
     /// Retrieve a file
     public func get(file path: String) throws -> EventLoopFuture<Data?> {

--- a/Sources/GitHubKit/GitHubClient.swift
+++ b/Sources/GitHubKit/GitHubClient.swift
@@ -10,6 +10,7 @@ public protocol GitHubClient {
     func put<C, E>(path: String, post: E) throws -> EventLoopFuture<C?> where C: Decodable, E: Encodable
     func patch<C, E>(path: String, post: E) throws -> EventLoopFuture<C?> where C: Decodable, E: Encodable
     func delete(path: String) throws -> EventLoopFuture<Void>
+    func delete<C, E>(path: String, post: E) throws -> EventLoopFuture<C?> where C: Decodable, E: Encodable
     func get(file path: String) throws -> EventLoopFuture<Data?>
     func redirect(file path: String, status: HTTPResponseStatus) throws -> EventLoopFuture<String>
     func download(org: String, repo: String, ref: String, format: GitHub.Format) throws -> EventLoopFuture<String>


### PR DESCRIPTION
- API current returns a content/file and commit object.
- Ref: [https://docs.github.com/en/rest/reference/repos#delete-a-file](url)